### PR TITLE
Fix block comments collisions for CBD, CSC, CCD, OLFD, ORFD and OMD mutations

### DIFF
--- a/src/operators/standard/catch-block-deletion.js
+++ b/src/operators/standard/catch-block-deletion.js
@@ -18,7 +18,7 @@ CBDOperator.prototype.getMutations = function(file, source, visit) {
           lineStart = c.loc.start.line;
           lineEnd = c.loc.end.line;
           var original = source.slice(start, end);
-          var replacement = "/*" + original + "*/";
+          var replacement = "";
           mutations.push(new Mutation(file, start, end, lineStart, lineEnd, original, replacement, this.ID));
         });
       }

--- a/src/operators/standard/conditional-statement-change.js
+++ b/src/operators/standard/conditional-statement-change.js
@@ -24,7 +24,7 @@ CSCOperator.prototype.getMutations = function(file, source, visit) {
         lineStart = node.trueBody.loc.start.line;
         lineEnd = node.falseBody.loc.end.line;
         original = source.slice(start, end);
-        var replacement = "/*" + original + "*/";
+        var replacement = "";
         mutations.push(new Mutation(file, start, end, lineStart, lineEnd, original, replacement, this.ID));
       }
 

--- a/src/operators/standard/constructor-deletion.js
+++ b/src/operators/standard/constructor-deletion.js
@@ -16,7 +16,7 @@ CCDOperator.prototype.getMutations = function(file, source, visit) {
         var lineStart = node.loc.start.line;
         var lineEnd = node.loc.end.line;
         const original = source.slice(start, end);
-        const replacement = "/* " + original + " */";
+        const replacement = "";
         mutations.push(new Mutation(file, start, end, lineStart, lineEnd, original, replacement, this.ID));
       }
     }

--- a/src/operators/standard/overloaded-function-deletion.js
+++ b/src/operators/standard/overloaded-function-deletion.js
@@ -45,7 +45,7 @@ OLFDOperator.prototype.getMutations = function(file, source, visit) {
         const startLine = node.loc.start.line;
         const endLine = node.loc.end.line; 
         const original = source.slice(start, end);
-        const replacement = "/*" + original + "*/";
+        const replacement = "";
         mutations.push(new Mutation(file, start, end, startLine, endLine, original, replacement, ID));
       }
     });

--- a/src/operators/standard/overridden-function-deletion.js
+++ b/src/operators/standard/overridden-function-deletion.js
@@ -22,7 +22,7 @@ ORFDOperator.prototype.getMutations = function(file, source, visit) {
                 const startLine = node.loc.start.line;
                 const endLine = node.loc.end.line; 
                 var original = source.slice(start, end);
-                replacement = "/*" + original + "*/";
+                replacement = "";
                 mutations.push(new Mutation(file, start, end, startLine, endLine, original, replacement, this.ID));
               }
               ranges.push(node.range);

--- a/src/operators/standard/overridden-modifier-deletion.js
+++ b/src/operators/standard/overridden-modifier-deletion.js
@@ -19,7 +19,7 @@ OMDOperator.prototype.getMutations = function(file, source, visit) {
               const startLine = node.loc.start.line;
               const endLine = node.loc.end.line; 
               var original = source.slice(start, end);
-              replacement = "/*" + original + "*/";
+              replacement = "";
               mutations.push(new Mutation(file, start, end, startLine, endLine, original, replacement, this.ID));
             }
           }


### PR DESCRIPTION
# Summary
This pull request addresses an issue where certain mutations in the library use block comments to disable specific block of code, resulting in collusions with block comments within the commented block. This collision leads to compilation errors and stillborn mutants as a result. 

The issue is valid for the next mutation types:
- Catch block deletion (CBD)
- Conditional Statement Change (CSC)
- Contract Constructor Deletion	(CCD)
- Overloaded Function Deletion (OLFD)
- Overridden Function Deletion (ORFD)
- Overridden Modifier Deletion (OMD)


# Description
For example, consider the code snippet before Conditional Statement Change (CSC) mutation:
```solidity
if (true) {
    // some code
} else {
    /*
        block comment
    */
    // another code
}
```
After the mutation, the code becomes:
```solidity
if (true) {
    // some code
} /* else {
    /*
        block comment
    */
    // another code
} */
```

Consequently, the compilation fails due to the presence of nested block comments, which is not allowed in Solidity. Any mutation that leads to failed compilation is considered a stillborn mutant.

To calculate the mutation score, the following formula is used:
```
mutationScore = killed / (survived + killed)
```

However, stillborn mutants are not considered in the mutation score calculation. This pull request proposes a fix that will enable the recognition of previously stillborn mutants as either "killed" or "survived," thereby increasing the precision and correctness of the mutation score.

_Note: There is an alternative option to replace block comments with line comments. However, this method affects the code execution speed, particularly for large blocks of code._



