### PR TITLE
Clarify config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ module.exports = {
   buildDir: 'build',
   contractsDir: 'contracts',
   testDir: 'test',
-  skipContracts: ['contractName.sol'],
-  skipTests: ['testDir/testFileName.js'],
+  skipContracts: ['contractName.sol'], // Relative paths from contractsDir
+  skipTests: ['testFileName.js'], // Relative paths from testDir
   testingTimeOutInSec: 300,
   network: "none",
   testingFramework: "truffle",


### PR DESCRIPTION
Currently one could be mistaken and add full paths to contracts/tests, while they only need relative to test/contract dirs.